### PR TITLE
Switch from node-expat to sax for XML parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
-        "node-expat": "^2.3.15"
+        "sax": "^1.4.1"
       },
       "devDependencies": {
         "tape": "^4.6.3"
@@ -97,14 +97,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -402,11 +394,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -935,21 +922,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/nan": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.20.0.tgz",
-      "integrity": "sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw=="
-    },
-    "node_modules/node-expat": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/node-expat/-/node-expat-2.4.1.tgz",
-      "integrity": "sha512-uWgvQLgo883NKIL+66oJsK9ysKK3ej0YjVCPBZzO/7wMAuH68/Yb7+JwPWNaVq0yPaxrb48AoEXfYEc8gsmFbg==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "nan": "^2.19.0"
-      }
-    },
     "node_modules/object-inspect": {
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
@@ -1104,6 +1076,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/OSMCha/osm-adiff-parser#readme",
   "dependencies": {
-    "node-expat": "^2.3.15"
+    "sax": "^1.4.1"
   },
   "devDependencies": {
     "tape": "^4.6.3"


### PR DESCRIPTION
Based on #1; that PR should be merged first.

Switches from using [`node-expat`](https://www.npmjs.com/package/node-expat) for parsing XML to [`sax`](https://www.npmjs.com/package/sax). `node-expat` is a set of bindings around `libexpat`, and consequently only works in Node. `sax` is a pure JS implementation. It has zero dependencies (native or otherwise) and works in both Node and browsers.

Sax is slightly slower than node-expat (about 25% slower based on the benchmark I described in #1), but if we accept that slowdown then we can have a single adiff parsing package that works everywhere. And besides, the performance lost here is more than made up for by the changes in #1, so overall `osm-adiff-parser` will still be substantially faster than before.

Once this is merged and published to npm, [`osm-adiff-parser-saxjs`](https://github.com/OSMCha/osm-adiff-parser-saxjs) can be deprecated.