### PR TITLE
Switch to a promise-based API, remove `changesetsFilter` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var sax = require('sax');
 
 // Returns elements grouped by changeset ID.
 
-function AugmentedDiffParser (xmlData, changesetsFilter) {
+function AugmentedDiffParser(xmlData, changesetsFilter) {
   return new Promise((resolve, reject) => {
     var xmlParser = sax.parser(true /* strict mode */, { lowercase: true });
     var currentAction = '';
@@ -12,11 +12,11 @@ function AugmentedDiffParser (xmlData, changesetsFilter) {
     var currentMode = '';
     var changesetMap = {};
 
-    function isElement (symbol) {
-      return (symbol === 'node' || symbol === 'way' || symbol === 'relation');
+    function isElement(symbol) {
+      return symbol === 'node' || symbol === 'way' || symbol === 'relation';
     }
 
-    function endTag (symbol) {
+    function endTag(symbol) {
       if (symbol === 'action') {
         var changeset = currentElement.changeset;
         if (changesetsFilter && changesetsFilter.length) {
@@ -28,11 +28,11 @@ function AugmentedDiffParser (xmlData, changesetsFilter) {
             }
           }
         } else {
-            if (changesetMap[changeset]) {
-              changesetMap[changeset].push(currentElement);
-            } else {
-              changesetMap[changeset] = [currentElement];
-            }
+          if (changesetMap[changeset]) {
+            changesetMap[changeset].push(currentElement);
+          } else {
+            changesetMap[changeset] = [currentElement];
+          }
         }
       }
       if (symbol === 'osm') {
@@ -40,7 +40,7 @@ function AugmentedDiffParser (xmlData, changesetsFilter) {
       }
     }
 
-    function startTag (node) {
+    function startTag(node) {
       var symbol = node.name;
       var attrs = node.attributes;
 
@@ -51,8 +51,7 @@ function AugmentedDiffParser (xmlData, changesetsFilter) {
         currentMode = symbol;
       }
       if (isElement(symbol)) {
-        if (currentMode === 'new' && (currentAction === 'modify' ||
-                                      currentAction === 'delete')) {
+        if (currentMode === 'new' && (currentAction === 'modify' || currentAction === 'delete')) {
           oldElement = currentElement;
           currentElement = attrs;
           currentElement.old = oldElement;
@@ -62,8 +61,13 @@ function AugmentedDiffParser (xmlData, changesetsFilter) {
         currentElement.action = currentAction;
         currentElement.type = symbol;
         currentElement.tags = {};
-        if (symbol === 'way') {currentElement.nodes = []; }
-        if (symbol === 'relation') {currentElement.members = []; currentMember = {};}
+        if (symbol === 'way') {
+          currentElement.nodes = [];
+        }
+        if (symbol === 'relation') {
+          currentElement.members = [];
+          currentMember = {};
+        }
       }
       if (symbol === 'tag' && currentElement) {
         currentElement.tags[attrs.k] = attrs.v;
@@ -89,8 +93,7 @@ function AugmentedDiffParser (xmlData, changesetsFilter) {
     xmlParser.onerror = reject;
     xmlParser.write(xmlData);
     xmlParser.close();
-  })
+  });
 }
 
 module.exports = AugmentedDiffParser;
-

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var sax = require('sax');
 
 // Returns elements grouped by changeset ID.
 
-function AugmentedDiffParser(xmlData, changesetsFilter) {
+function AugmentedDiffParser(xmlData) {
   return new Promise((resolve, reject) => {
     var xmlParser = sax.parser(true /* strict mode */, { lowercase: true });
     var currentAction = '';
@@ -18,22 +18,11 @@ function AugmentedDiffParser(xmlData, changesetsFilter) {
 
     function endTag(symbol) {
       if (symbol === 'action') {
-        var changeset = currentElement.changeset;
-        if (changesetsFilter && changesetsFilter.length) {
-          if (changesetsFilter.indexOf(changeset) !== -1) {
-            if (changesetMap[changeset]) {
-              changesetMap[changeset].push(currentElement);
-            } else {
-              changesetMap[changeset] = [currentElement];
-            }
-          }
-        } else {
-          if (changesetMap[changeset]) {
-            changesetMap[changeset].push(currentElement);
-          } else {
-            changesetMap[changeset] = [currentElement];
-          }
+        var changesetId = currentElement.changeset;
+        if (changesetMap[changesetId] === undefined) {
+          changesetMap[changesetId] = [];
         }
+        changesetMap[changesetId].push(currentElement);
       }
       if (symbol === 'osm') {
         resolve(changesetMap);

--- a/index.js
+++ b/index.js
@@ -2,92 +2,94 @@ var sax = require('sax');
 
 // Returns elements grouped by changeset ID.
 
-function AugmentedDiffParser (xmlData, changesetsFilter, callback) {
-  var xmlParser = sax.parser(true /* strict mode */, { lowercase: true });
-  var currentAction = '';
-  var currentElement = {};
-  var oldElement = {};
-  var currentMember = {};
-  var currentMode = '';
-  var changesetMap = {};
+function AugmentedDiffParser (xmlData, changesetsFilter) {
+  return new Promise((resolve, reject) => {
+    var xmlParser = sax.parser(true /* strict mode */, { lowercase: true });
+    var currentAction = '';
+    var currentElement = {};
+    var oldElement = {};
+    var currentMember = {};
+    var currentMode = '';
+    var changesetMap = {};
 
-  function isElement (symbol) {
-    return (symbol === 'node' || symbol === 'way' || symbol === 'relation');
-  }
+    function isElement (symbol) {
+      return (symbol === 'node' || symbol === 'way' || symbol === 'relation');
+    }
 
-  function endTag (symbol) {
-    if (symbol === 'action') {
-      var changeset = currentElement.changeset;
-      if (changesetsFilter && changesetsFilter.length) {
-        if (changesetsFilter.indexOf(changeset) !== -1) {
-          if (changesetMap[changeset]) {
-            changesetMap[changeset].push(currentElement);
-          } else {
-            changesetMap[changeset] = [currentElement];
+    function endTag (symbol) {
+      if (symbol === 'action') {
+        var changeset = currentElement.changeset;
+        if (changesetsFilter && changesetsFilter.length) {
+          if (changesetsFilter.indexOf(changeset) !== -1) {
+            if (changesetMap[changeset]) {
+              changesetMap[changeset].push(currentElement);
+            } else {
+              changesetMap[changeset] = [currentElement];
+            }
           }
+        } else {
+            if (changesetMap[changeset]) {
+              changesetMap[changeset].push(currentElement);
+            } else {
+              changesetMap[changeset] = [currentElement];
+            }
         }
-      } else {
-          if (changesetMap[changeset]) {
-            changesetMap[changeset].push(currentElement);
-          } else {
-            changesetMap[changeset] = [currentElement];
-          }
+      }
+      if (symbol === 'osm') {
+        resolve(changesetMap);
       }
     }
-    if (symbol === 'osm') {
-      callback(null, changesetMap);
-    }
-  }
 
-  function startTag (node) {
-    var symbol = node.name;
-    var attrs = node.attributes;
+    function startTag (node) {
+      var symbol = node.name;
+      var attrs = node.attributes;
 
-    if (symbol === 'action') {
-      currentAction = attrs.type;
-    }
-    if (symbol === 'new' || symbol === 'old') {
-      currentMode = symbol;
-    }
-    if (isElement(symbol)) {
-      if (currentMode === 'new' && (currentAction === 'modify' ||
-                                    currentAction === 'delete')) {
-        oldElement = currentElement;
-        currentElement = attrs;
-        currentElement.old = oldElement;
-      } else {
-        currentElement = attrs;
+      if (symbol === 'action') {
+        currentAction = attrs.type;
       }
-      currentElement.action = currentAction;
-      currentElement.type = symbol;
-      currentElement.tags = {};
-      if (symbol === 'way') {currentElement.nodes = []; }
-      if (symbol === 'relation') {currentElement.members = []; currentMember = {};}
-    }
-    if (symbol === 'tag' && currentElement) {
-      currentElement.tags[attrs.k] = attrs.v;
+      if (symbol === 'new' || symbol === 'old') {
+        currentMode = symbol;
+      }
+      if (isElement(symbol)) {
+        if (currentMode === 'new' && (currentAction === 'modify' ||
+                                      currentAction === 'delete')) {
+          oldElement = currentElement;
+          currentElement = attrs;
+          currentElement.old = oldElement;
+        } else {
+          currentElement = attrs;
+        }
+        currentElement.action = currentAction;
+        currentElement.type = symbol;
+        currentElement.tags = {};
+        if (symbol === 'way') {currentElement.nodes = []; }
+        if (symbol === 'relation') {currentElement.members = []; currentMember = {};}
+      }
+      if (symbol === 'tag' && currentElement) {
+        currentElement.tags[attrs.k] = attrs.v;
+      }
+
+      if (symbol === 'nd' && currentElement && currentElement.type === 'way') {
+        currentElement.nodes.push(attrs);
+      }
+
+      if (symbol === 'nd' && currentElement && currentElement.type === 'relation') {
+        currentMember.nodes.push(attrs);
+      }
+
+      if (symbol === 'member' && currentElement && currentElement.type === 'relation') {
+        currentMember = attrs;
+        currentMember.nodes = [];
+        currentElement.members.push(currentMember);
+      }
     }
 
-    if (symbol === 'nd' && currentElement && currentElement.type === 'way') {
-      currentElement.nodes.push(attrs);
-    }
-
-    if (symbol === 'nd' && currentElement && currentElement.type === 'relation') {
-      currentMember.nodes.push(attrs);
-    }
-
-    if (symbol === 'member' && currentElement && currentElement.type === 'relation') {
-      currentMember = attrs;
-      currentMember.nodes = [];
-      currentElement.members.push(currentMember);
-    }
-  }
-
-  xmlParser.onopentag = startTag;
-  xmlParser.onclosetag = endTag;
-  xmlParser.onerror = function(err) { callback(err, null); };
-  xmlParser.write(xmlData);
-
+    xmlParser.onopentag = startTag;
+    xmlParser.onclosetag = endTag;
+    xmlParser.onerror = reject;
+    xmlParser.write(xmlData);
+    xmlParser.close();
+  })
 }
 
 module.exports = AugmentedDiffParser;

--- a/tests/index.js
+++ b/tests/index.js
@@ -13,10 +13,10 @@ const filenames =
 filenames.forEach(function(filename) {
   tape(`testing file: ${filename}`, function(t) {
     const xml = fs.readFileSync(`tests/data/${filename}.osc`, { encoding: 'utf-8' });
-    const expectedJSON = JSON.parse(fs.readFileSync(`tests/data/${filename}.json`));
+    const expected = JSON.parse(fs.readFileSync(`tests/data/${filename}.json`));
 
-    parser(xml, null, function(error, actualJSON) {
-      t.deepEqual(actualJSON, expectedJSON, 'parsed correctly');
+    parser(xml, null).then((actual) => {
+      t.deepEqual(actual, expected, 'parsed correctly');
       t.end();
     });
   });


### PR DESCRIPTION
Our only two consumers of this API (that I know of) are [changesets-map](https://github.com/osmlab/changeset-map/blob/db7fd0cdd1f15903fcc59fe9fb17d0b764a03b83/lib/getChangeset.js#L48) and [osm-adiff-service](https://github.com/OSMCha/osm-adiff-service/blob/main/lib/get-changesets.js#L57), though the latter uses a copy-pasted version of this parser. changesets-map wraps the callback API in a promise, and osm-adiff-service's copy of the parser is synchronous, but is called from an async function so a promise-based API would be equally easy to use. In light of that, this PR changes `osm-adiff-parser`'s main function to return a promise.

The other change in this PR is to remove the `changesetsFilter` option. This option seems pretty special-purpose, wasn't used by any consumer that I know of, and can easily be implemented by the caller if desired.

These are breaking changes, and are the only breaking changes that I think should be made at this time. Once this PR is merged I'll publish v2.0.0 of this package to `@osmcha/osm-adiff-service` on npm.

Note: most of the changes are whitespace-only so disable whitespace in Github's diff viewer for easier reviewing.